### PR TITLE
[Importer-Db-Api] basic auth as alternative authorization

### DIFF
--- a/importer-db-api/src/routes/personGroups.js
+++ b/importer-db-api/src/routes/personGroups.js
@@ -5,11 +5,31 @@ const https = require('https')
 
 const models = require('../models')
 
-const { SIS_API_URL, PROXY_TOKEN, OODIKONE_KEY_PATH, OODIKONE_CERT_PATH, OODIKONE_API_KEY } = process.env
+const {
+  SIS_API_URL,
+  PROXY_TOKEN,
+  OODIKONE_KEY_PATH,
+  OODIKONE_CERT_PATH,
+  OODIKONE_API_KEY,
+  SIS_API_USER,
+  SIS_API_PASSWORD
+} = process.env
 
 const hasCerts = OODIKONE_KEY_PATH && OODIKONE_CERT_PATH
 
+const getSisBasicAuthHeader = () => {
+  const auth = `${SIS_API_USER}:${SIS_API_PASSWORD}`
+  const token = Buffer.from(auth).toString('base64')
+  return {
+    Authorization: 'Basic ' + token
+  }
+}
+
 const getHeaders = () => {
+  const basicAuthProvided = SIS_API_USER && SIS_API_PASSWORD
+  if (basicAuthProvided) {
+    return getSisBasicAuthHeader()
+  }
   if (!hasCerts) return { token: PROXY_TOKEN || '' }
   else if (hasCerts && OODIKONE_API_KEY) return { 'X-Api-Key': OODIKONE_API_KEY }
   return {}


### PR DESCRIPTION
FD needs to be able to make requests to ori-endpoint using basic auth. (DO NOT MERGE BEFORE FD APPROVAL)