### PR TITLE
[importer-api] Added logger prodFormat serviceProvider check and returning mock message in fd enviroments

### DIFF
--- a/importer-api/src/utils/logger.js
+++ b/importer-api/src/utils/logger.js
@@ -37,12 +37,18 @@ if (!IS_DEV) {
     silly: 6
   }
 
-  const prodFormat = winston.format.printf(({ level, ...rest }) =>
-    JSON.stringify({
-      level: levels[level],
-      ...rest
-    })
-  )
+  const prodFormat = winston.format.printf(({ level, ...rest }) => {
+    if (SERVICE_PROVIDER !== 'fd') {
+      return JSON.stringify({
+        level: levels[level],
+        ...rest
+      })
+    } else {
+      return JSON.stringify({
+        funidata: 'Mock message'
+      })
+    }
+  })
 
   transports.push(new winston.transports.Console({ format: prodFormat }))
 


### PR DESCRIPTION
Quick fix for problem caused by JSON.stringify in importer-api logger

`{"level":0,"message":"Importing failed","meta":"TypeError: Converting circular structure to JSON\n    --> starting at object with constructor 'TLSSocket'\n    |     property '_httpMessage' -> object with constructor 'ClientRequest'\n    --- property 'socket' closes the circle\n    at JSON.stringify (<anonymous>)\n    at Printf.template (/opt/app-root/src/src/utils/logger.js:41:10)\n    at Printf.transform (/opt/app-root/src/node_modules/winston/node_modules/logform/printf.js:11:26)\n    at Console._write (/opt/app-root/src/node_modules/winston/node_modules/winston-transport/modern.js:91:33)\n    at writeOrBuffer (/opt/app-root/src/node_modules/winston/node_modules/winston-transport/node_modules/readable-stream/lib/internal/streams/writable.js:334:12)\n    at _write (/opt/app-root/src/node_modules/winston/node_modules/winston-transport/node_modules/readable-stream/lib/internal/streams/writable.js:283:10)\n    at Writable.write (/opt/app-root/src/node_modules/winston/node_modules/winston-transport/node_modules/readable-stream/lib/internal/streams/writable.js:286:10)\n    at DerivedLogger.ondata (/opt/app-root/src/node_modules/readable-stream/lib/_stream_readable.js:681:20)\n    at DerivedLogger.emit (node:events:536:35)\n    at addChunk (/opt/app-root/src/node_modules/readable-stream/lib/_stream_readable.js:298:12)"}`